### PR TITLE
Fix broken links in comments

### DIFF
--- a/css/apocrypha.css
+++ b/css/apocrypha.css
@@ -28,7 +28,7 @@
 
 /**
  * Contains styling for inline tags as defined in the following section:
- * https://developer.quote.org/en-US/docs/Web/HTML/Element#forms
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Element#forms
  */
 button {
   background: var(--background-secondary);

--- a/scss/page/_forms.scss
+++ b/scss/page/_forms.scss
@@ -1,6 +1,6 @@
 /**
  * Contains styling for inline tags as defined in the following section:
- * https://developer.quote.org/en-US/docs/Web/HTML/Element#forms
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Element#forms
  */
 
 @import "../options";


### PR DESCRIPTION
`scss/page/_forms.scss` contains a broken reference to `developer.mozilla.org`, which this PR fixes.