### PR TITLE
`fieldset` styling

### DIFF
--- a/scss/page/_forms.scss
+++ b/scss/page/_forms.scss
@@ -1,5 +1,5 @@
 /**
- * Contains styling for inline tags as defined in the following section:
+ * Contains styling for form tags as defined in the following section:
  * https://developer.quote.org/en-US/docs/Web/HTML/Element#forms
  */
 
@@ -102,6 +102,12 @@ textarea {
   padding: 0.5rem;
   resize: vertical;
   width: none;
+}
+
+fieldset {
+  border: thin solid var(--accent-primary);
+  border-radius: var(--corner-radius);
+  margin-block: 0.5rem;
 }
 
 button:focus,


### PR DESCRIPTION
This PR introduces styling to the `fieldset` element. I'm happy to just build some groundwork for @BraveeSnow to finalize, as I don't have his creative vision for the project :D

That being said, here's a before and after:

<p align="center">
  <img src="https://github.com/ApocryphaCSS/apocrypha.css/assets/69081152/e99bc5e0-e0a0-43d0-a116-5d1e1ce859cd" />
  <img src="https://github.com/ApocryphaCSS/apocrypha.css/assets/69081152/c46edc72-1a03-4352-886b-1486b8b2b4bd" /></p>

Some thoughts on the current styling:

- Potential for "visual busyness" caused by similar border styling of `fieldset` and inner `button`s or `input`s. Could be fixed by using a different colour for `fieldset` border?